### PR TITLE
Logic to skip mount if providername is nil

### DIFF
--- a/lib/puppet/provider/mount/windows_smb.rb
+++ b/lib/puppet/provider/mount/windows_smb.rb
@@ -87,13 +87,17 @@ Puppet::Type.type(:mount).provide(:windows_smb, :parent => Puppet::Provider) do
     end
 
     mounts.each { |mount|
-      status = execute(['net', 'use', mount['Name']]).to_s.split("\n").reject { |line|
-        ! line.start_with?("Status")
-      }.map { |line|
-        line.split.last.strip
-      }.join
+      if mount['ProviderName'].nil?
+        mounts.delete(mount)
+      else
+        status = execute(['net', 'use', mount['Name']]).to_s.split("\n").reject { |line|
+          ! line.start_with?("Status")
+        }.map { |line|
+          line.split.last.strip
+        }.join
 
-      mount["Status"] = status
+        mount["Status"] = status
+      end
     }
 
     mounts.map { |mount|


### PR DESCRIPTION
'net use' will fail if the mount retrieved has a provider of 'null'. This update checks to see if the provider is valid prior to doing a net use and if not, removes the entry from the mounts hash before processing the next mount